### PR TITLE
Messages should be ordered by newest message (not oldest)

### DIFF
--- a/lib/acts-as-messageable/message.rb
+++ b/lib/acts-as-messageable/message.rb
@@ -26,7 +26,7 @@ module ActsAsMessageable
 
 
     # Sample documentation for scope
-    default_scope order(:created_at)
+    default_scope order("created_at desc")
     scope :are_from,          lambda { |*args| where("sent_messageable_id = :sender AND sent_messageable_type = :sender_type", :sender => args.first, :sender_type => args.first.class.to_s) }
     scope :are_to,            lambda { |*args| where("received_messageable_id = :receiver AND received_messageable_type = :receiver_type", :receiver => args.first, :receiver_type => args.first.class.to_s) }
     scope :with_id,           lambda { |*args| where("id = :id", :id => args.first) }

--- a/spec/acts-as-messageable_spec.rb
+++ b/spec/acts-as-messageable_spec.rb
@@ -139,8 +139,8 @@ describe "ActsAsMessageable" do
       @reply_message =  @alice.reply_to(@message, "Re: Topic", "Body")
 
       @reply_message.conversation.size.should == 2
-      @reply_message.conversation.first.topic.should == "Topic"
-      @reply_message.conversation.last.topic.should == "Re: Topic"
+      @reply_message.conversation.last.topic.should == "Topic"
+      @reply_message.conversation.first.topic.should == "Re: Topic"
     end
 
     it "bob send message to alice, alice answer, and bob answer for alice answer" do
@@ -152,8 +152,8 @@ describe "ActsAsMessageable" do
         m.conversation.size.should == 3
       end
 
-      @message.conversation.last.should == @reply_reply_message
-      @reply_reply_message.conversation.last.should == @reply_reply_message
+      @message.conversation.first.should == @reply_reply_message
+      @reply_reply_message.conversation.first.should == @reply_reply_message
     end
   end
 
@@ -168,7 +168,7 @@ describe "ActsAsMessageable" do
   it "messages should return in right order :created_at" do
     @message = send_message
     @message = send_message(@bob, @alice, "Example", "Example Body")
-    @alice.messages.first.body.should == "Body"
+    @alice.messages.last.body.should == "Body"
   end
 
   it "received_messages should return ActiveRecord::Relation" do


### PR DESCRIPTION
In a typical web app, you want to see the newest messages first. The default scope orders them by oldest first, so I committed a change to fix that. 
