### PR TITLE
Update message.rb

### DIFF
--- a/lib/acts-as-messageable/message.rb
+++ b/lib/acts-as-messageable/message.rb
@@ -8,6 +8,7 @@ module ActsAsMessageable
     belongs_to :sent_messageable,     :polymorphic => true
 
     attr_accessor   :removed, :restored
+    attr_accessible :topic, :body
     cattr_accessor  :required
 
     ActsAsMessageable.rails_api.new(self).default_scope("created_at desc")


### PR DESCRIPTION
Just a little modification for Rails 4's error: 
WARNING: Can't mass-assign protected attributes for ActsAsMessageable::Message: topic, body

And  ofcourse this requires the protected attributes gem.

gem 'protected_attributes'