### PR TITLE
Migrated opened to be opened_at and a datetime field.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,4 +11,5 @@ group :development do
   gem "sqlite3"
   gem "coveralls", :require => false
   gem "appraisal"
+  gem "timecop"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -110,6 +110,7 @@ GEM
       tins (~> 1.0)
     thor (0.19.1)
     thread_safe (0.3.4)
+    timecop (0.7.1)
     tins (1.3.3)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
@@ -127,3 +128,4 @@ DEPENDENCIES
   railties (>= 3.0.0)
   rspec (~> 2.0)
   sqlite3
+  timecop

--- a/gemfiles/rails_3.0.gemfile
+++ b/gemfiles/rails_3.0.gemfile
@@ -13,4 +13,5 @@ group :development do
   gem "sqlite3"
   gem "coveralls", :require => false
   gem "appraisal"
+  gem "timecop"
 end

--- a/gemfiles/rails_3.1.gemfile
+++ b/gemfiles/rails_3.1.gemfile
@@ -13,4 +13,5 @@ group :development do
   gem "sqlite3"
   gem "coveralls", :require => false
   gem "appraisal"
+  gem "timecop"
 end

--- a/gemfiles/rails_3.2.gemfile
+++ b/gemfiles/rails_3.2.gemfile
@@ -13,4 +13,5 @@ group :development do
   gem "sqlite3"
   gem "coveralls", :require => false
   gem "appraisal"
+  gem "timecop"
 end

--- a/gemfiles/rails_4.0.gemfile
+++ b/gemfiles/rails_4.0.gemfile
@@ -13,4 +13,5 @@ group :development do
   gem "sqlite3"
   gem "coveralls", :require => false
   gem "appraisal"
+  gem "timecop"
 end

--- a/gemfiles/rails_4.1.gemfile
+++ b/gemfiles/rails_4.1.gemfile
@@ -13,4 +13,5 @@ group :development do
   gem "sqlite3"
   gem "coveralls", :require => false
   gem "appraisal"
+  gem "timecop"
 end

--- a/gemfiles/rails_4.1_ProtectedAttributes.gemfile
+++ b/gemfiles/rails_4.1_ProtectedAttributes.gemfile
@@ -14,4 +14,5 @@ group :development do
   gem "sqlite3"
   gem "coveralls", :require => false
   gem "appraisal"
+  gem "timecop"
 end

--- a/lib/acts-as-messageable/message.rb
+++ b/lib/acts-as-messageable/message.rb
@@ -17,7 +17,7 @@ module ActsAsMessageable
     end
 
     def opened?
-      open.nil?
+      opened_at.present?
     end
 
     def open

--- a/lib/acts-as-messageable/message.rb
+++ b/lib/acts-as-messageable/message.rb
@@ -16,6 +16,10 @@ module ActsAsMessageable
       self.opened?
     end
 
+    def opened?
+      open.nil?
+    end
+
     def open
       update_attributes!(:opened_at => DateTime.now)
     end

--- a/lib/acts-as-messageable/message.rb
+++ b/lib/acts-as-messageable/message.rb
@@ -17,13 +17,13 @@ module ActsAsMessageable
     end
 
     def open
-      update_attributes!(:opened => true)
+      update_attributes!(:opened => true, :opened_at => DateTime.now)
     end
     alias :mark_as_read :open
     alias :read         :open
 
     def close
-      update_attributes!(:opened => false)
+      update_attributes!(:opened => false, :opened_at => nil)
     end
     alias :mark_as_unread :close
     alias :unread         :close

--- a/lib/acts-as-messageable/message.rb
+++ b/lib/acts-as-messageable/message.rb
@@ -17,13 +17,13 @@ module ActsAsMessageable
     end
 
     def open
-      update_attributes!(:opened => true, :opened_at => DateTime.now)
+      update_attributes!(:opened_at => DateTime.now)
     end
     alias :mark_as_read :open
     alias :read         :open
 
     def close
-      update_attributes!(:opened => false, :opened_at => nil)
+      update_attributes!(:opened_at => nil)
     end
     alias :mark_as_unread :close
     alias :unread         :close

--- a/lib/acts-as-messageable/scopes.rb
+++ b/lib/acts-as-messageable/scopes.rb
@@ -28,8 +28,8 @@ module ActsAsMessageable
                                                   :r_perm_delete  => false,
                                                   :s_perm_delete  => false)
         }
-        scope :readed,            lambda { where(:opened => true)  }
-        scope :unreaded,          lambda { where(:opened => false) }
+        scope :readed,            lambda { where.not(:opened_at => nil)  }
+        scope :unreaded,          lambda { where(:opened_at => nil) }
         scope :deleted,           lambda { where(:recipient_delete => true, :sender_delete => true) }
       end
     end

--- a/lib/acts-as-messageable/scopes.rb
+++ b/lib/acts-as-messageable/scopes.rb
@@ -28,7 +28,7 @@ module ActsAsMessageable
                                                   :r_perm_delete  => false,
                                                   :s_perm_delete  => false)
         }
-        scope :readed,            lambda { where.not(:opened_at => nil)  }
+        scope :readed,            lambda { where.not(:opened_at => nil) }
         scope :unreaded,          lambda { where(:opened_at => nil) }
         scope :deleted,           lambda { where(:recipient_delete => true, :sender_delete => true) }
       end

--- a/lib/acts-as-messageable/scopes.rb
+++ b/lib/acts-as-messageable/scopes.rb
@@ -28,7 +28,7 @@ module ActsAsMessageable
                                                   :r_perm_delete  => false,
                                                   :s_perm_delete  => false)
         }
-        scope :readed,            lambda { where.not(:opened_at => nil) }
+        scope :readed,            lambda { where('opened_at is not null') }
         scope :unreaded,          lambda { where(:opened_at => nil) }
         scope :deleted,           lambda { where(:recipient_delete => true, :sender_delete => true) }
       end

--- a/lib/generators/acts-as-messageable/migration/migration_generator.rb
+++ b/lib/generators/acts-as-messageable/migration/migration_generator.rb
@@ -17,6 +17,7 @@ module ActsAsMessageable
     def create_migration_file
       migration_template 'migration.rb', 'db/migrate/create_messages_table.rb' rescue nil
       migration_template 'migration_permanent.rb', 'db/migrate/add_recipient_permanent_delete_and_sender_permanent_delete_to_messages.rb' rescue nil
+      migration_template 'migration_opened_as_datetime.rb', 'db/migrate/add_opened_at_to_messages.rb' rescue nil
     end
   end
 end

--- a/lib/generators/acts-as-messageable/migration/migration_generator.rb
+++ b/lib/generators/acts-as-messageable/migration/migration_generator.rb
@@ -16,7 +16,8 @@ module ActsAsMessageable
 
     def create_migration_file
       migration_template 'migration.rb', 'db/migrate/create_messages_table.rb' rescue nil
-      migration_template 'migration_permanent.rb', 'db/migrate/add_recipient_permanent_delete_and_sender_permanent_delete_to_messages.rb' rescue nil
+      migration_template 'migration_permanent.rb',
+        'db/migrate/add_recipient_permanent_delete_and_sender_permanent_delete_to_messages.rb' rescue nil
       migration_template 'migration_opened_as_datetime.rb', 'db/migrate/add_opened_at_to_messages.rb' rescue nil
     end
   end

--- a/lib/generators/acts-as-messageable/migration/templates/migration_opened_as_datetime.rb
+++ b/lib/generators/acts-as-messageable/migration/templates/migration_opened_as_datetime.rb
@@ -1,0 +1,13 @@
+class AddOpenedAtToMessages < ActiveRecord::Migration
+  def self.up
+    add_column :<%= table_name %>, :opened_at, :datetime
+    <%= table_name.classify %>.where(opened:true).update_all(opened_at: DateTime.now)
+    remove_column :<%= table_name %>, :opened
+  end
+
+  def self.down
+    add_column :<%= table_name %>, :opened, :boolean, default: false
+    <%= table_name.classify %>.where.not(opened_at:nil).update_all(opened: true)
+    remove_column :<%= table_name %>, :opened_at
+  end
+end

--- a/spec/acts-as-messageable_spec.rb
+++ b/spec/acts-as-messageable_spec.rb
@@ -182,6 +182,14 @@ describe "ActsAsMessageable" do
       @alice.messages.are_from(@bob).unreaded.count.should == 1
     end
 
+    it "alice should see the read_at updated" do
+      date_time_when_read = Time.new(2014, 9, 4, 15, 12, 34)
+      Timecop.freeze(date_time_when_read) do
+        @alice.messages.are_from(@bob).first.read
+        expect(@alice.messages.are_from(@bob).first.opened_at).to eql(date_time_when_read)
+      end
+    end
+
     it "alice should able to get datetime when he read bob message" do
       @alice.messages.are_from(@bob).first.read
       read_datetime = @alice.messages.are_from(@bob).first.updated_at
@@ -266,11 +274,11 @@ describe "ActsAsMessageable" do
   end
 
   it "received_messages should return unloaded messages" do
-    @alice.received_messages.loaded?.should be_false
+    @alice.received_messages.loaded?.should be_falsey
   end
 
   it "sent_messages should return unloaded messages" do
-    @bob.sent_messages.loaded?.should be_false
+    @bob.sent_messages.loaded?.should be_falsey
   end
 
   describe "send messages between two different models (the same id)" do

--- a/spec/acts-as-messageable_spec.rb
+++ b/spec/acts-as-messageable_spec.rb
@@ -186,7 +186,8 @@ describe "ActsAsMessageable" do
       date_time_when_read = Time.new(2014, 9, 4, 15, 12, 34)
       Timecop.freeze(date_time_when_read) do
         @alice.messages.are_from(@bob).first.read
-        expect(@alice.messages.are_from(@bob).first.opened_at).to eql(date_time_when_read)
+        first_message = @alice.messages.are_from(@bob).first
+        expect(first_message.opened_at).to eql(date_time_when_read)
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,8 @@ ActiveRecord::Base.logger.level = 3
 require 'coveralls'
 Coveralls.wear!
 
+require 'timecop'
+
 require 'bundler/setup'
 Bundler.require(:default)
 
@@ -46,6 +48,7 @@ def create_database
       t.references :received_messageable, :polymorphic => true
       t.references :sent_messageable, :polymorphic => true
       t.boolean :opened, :default => false
+      t.datetime :opened_at
       t.boolean :recipient_delete, :default => false
       t.boolean :sender_delete, :default => false
       t.boolean :recipient_permanent_delete, :default => false

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -47,7 +47,6 @@ def create_database
       t.text :body
       t.references :received_messageable, :polymorphic => true
       t.references :sent_messageable, :polymorphic => true
-      t.boolean :opened, :default => false
       t.datetime :opened_at
       t.boolean :recipient_delete, :default => false
       t.boolean :sender_delete, :default => false
@@ -62,7 +61,7 @@ def create_database
       t.text :body
       t.references :received_messageable, :polymorphic => true
       t.references :sent_messageable, :polymorphic => true
-      t.boolean :opened, :default => false
+      t.datetime :opened_at
       t.boolean :recipient_delete, :default => false
       t.boolean :sender_delete, :default => false
       t.boolean :recipient_permanent_delete, :default => false


### PR DESCRIPTION
We had a need to have a clear read/opened at timestamp, so I've converted the opened boolean to be a datetime attribute that is set with the current time. specs have been updated and made to work with the change.  Migrations should support migrating data to use the new column (with a datetime of now for existing records).
