### PR TITLE
Add support for custom search scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,11 @@ Usage
 ```ruby
 class User < ActiveRecord::Base
   acts_as_messageable :table_name => "table_with_messages", # default 'messages'
-                      :required   => :body                  # default [:topic, :body]
-                      :class_name => "CustomMessages"       # default "ActsAsMessageable::Message",
-                      :dependent  => :destroy               # default :nullify
-                      :group_messages => true               # default false
+                      :required   => :body,                 # default [:topic, :body]
+                      :class_name => "CustomMessages",      # default "ActsAsMessageable::Message",
+                      :dependent  => :destroy,              # default :nullify
+                      :group_messages => true,              # default false
+                      :search_scope => :custom_search       # default :search
 end
 ```
 

--- a/lib/acts_as_messageable/model.rb
+++ b/lib/acts_as_messageable/model.rb
@@ -14,13 +14,15 @@ module ActsAsMessageable
       # @param [String] :class_name - message class name
       # @param [Array, Symbol] :required - required fields in message
       # @param [Symbol] :dependent - dependent option from ActiveRecord has_many method
+      # @param [Symbol] :search_scope - name of a scope for a full text search
       def acts_as_messageable(options = {})
         default_options = {
           table_name: 'messages',
           class_name: 'ActsAsMessageable::Message',
           required: %i[topic body],
           dependent: :nullify,
-          group_messages: false
+          group_messages: false,
+          search_scope: :search
         }
         options = default_options.merge(options)
 
@@ -37,7 +39,7 @@ module ActsAsMessageable
         messages_class_name.has_ancestry
 
         messages_class_name.table_name = options[:table_name]
-        messages_class_name.initialize_scopes
+        messages_class_name.initialize_scopes(options[:search_scope])
 
         messages_class_name.required = Array.wrap(options[:required])
         messages_class_name.validates_presence_of messages_class_name.required

--- a/lib/acts_as_messageable/scopes.rb
+++ b/lib/acts_as_messageable/scopes.rb
@@ -6,19 +6,15 @@ module ActsAsMessageable
   module Scopes
     extend ActiveSupport::Concern
 
-    included do
-      initialize_scopes
-    end
-
     module ClassMethods
-      def initialize_scopes
+      def initialize_scopes(search_scope)
         scope :are_from, lambda { |*args|
           where(sent_messageable_id: args.first, sent_messageable_type: args.first.class.name)
         }
         scope :are_to, lambda { |*args|
           where(received_messageable_id: args.first, received_messageable_type: args.first.class.name)
         }
-        scope :search, lambda { |*args|
+        scope search_scope, lambda { |*args|
           where('body like :search_txt or topic like :search_txt', search_txt: "%#{args.first}%")
         }
         scope :connected_with, lambda { |*args|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,6 +31,7 @@ RSpec.configure do |config|
     @pat = User.create email: 'pat@example.com'
     @admin = Admin.create email: 'admin@example.com'
     @men = Men.create email: 'men@example.com'
+    @custom_search_user = CustomSearchUser.create email: 'custom@example.com'
   end
 
   config.after(:all) do
@@ -47,13 +48,9 @@ def create_database
     create_table(:messages, &TABLE_SCHEMA)
     create_table(:custom_messages, &TABLE_SCHEMA)
 
-    create_table :users do |t|
-      t.string :email
-    end
-
-    create_table :admins do |t|
-      t.string :email
-    end
+    create_table(:users, &USER_SCHEMA)
+    create_table(:admins, &USER_SCHEMA)
+    create_table(:custom_search_users, &USER_SCHEMA)
   end
 end
 

--- a/spec/support/table_schema.rb
+++ b/spec/support/table_schema.rb
@@ -14,3 +14,7 @@ TABLE_SCHEMA = lambda do |t|
   t.string :ancestry
   t.timestamps
 end
+
+USER_SCHEMA = lambda do |t|
+  t.string :email
+end


### PR DESCRIPTION
Scope `search` for Message model can be used by admin-like gems. From
now you can customize `search` scope and change it to something else.