### PR TITLE
Initialize ancestry for Message class

### DIFF
--- a/lib/acts_as_messageable/message.rb
+++ b/lib/acts_as_messageable/message.rb
@@ -6,6 +6,8 @@ module ActsAsMessageable
   class Message < ::ActiveRecord::Base
     include ActsAsMessageable::Scopes
 
+    has_ancestry
+
     belongs_to :received_messageable, polymorphic: true
     belongs_to :sent_messageable, polymorphic: true
 

--- a/spec/acts_as_messageable_spec.rb
+++ b/spec/acts_as_messageable_spec.rb
@@ -330,4 +330,18 @@ describe 'ActsAsMessageable' do
       expect(@message.body).to eq('Changed body')
     end
   end
+
+  describe 'ancestry initialization' do # GH#78
+    let(:message) { ActsAsMessageable::Message.create!(topic: 'topic', body: 'body') }
+
+    before do
+      # Use clean version of Message class
+      ActsAsMessageable.instance_eval { remove_const 'Message' }
+      load 'acts_as_messageable/message.rb'
+    end
+
+    it 'returns root of the conversation' do
+      expect(message.conversation).to include(message)
+    end
+  end
 end


### PR DESCRIPTION
Message class was initialized with `has_ancestry` method _AFTER_ User
class had been loaded. It caused issues with rails console when someone
loaded only `ActsAsMessageable::Message` class.

Closes #78